### PR TITLE
Fix updateCategories naming

### DIFF
--- a/src/APICalls.ts
+++ b/src/APICalls.ts
@@ -569,7 +569,7 @@ export async function searchPosts(
   }
 }
 
-export async function updateCateogories(
+export async function updateCategories(
   id: string,
   field: string,
   newValue: any,

--- a/src/Components/CreatePostDialogue.tsx
+++ b/src/Components/CreatePostDialogue.tsx
@@ -13,7 +13,7 @@ import {
   FormControl,
 } from "@mui/material";
 import { useState } from "react";
-import { createPost, patchUser, updateCateogories } from "../APICalls";
+import { createPost, patchUser, updateCategories } from "../APICalls";
 import { TextGlitchEffect } from "./TextGlitchEffect";
 import { useSnackbar } from "notistack";
 import { Category, errorProps } from "../../dataTypeDefinitions";
@@ -60,9 +60,9 @@ function CreatePostDialogue({
             field: "posts",
             newValue: [...userData.posts, data.id],
             onSuccess: () => {
-              updateCateogories(
-                category, 
-                "posts", 
+              updateCategories(
+                category,
+                "posts",
                 [
                   ...(categories.find((cat) => cat.id === category)?.posts ||
                     []),


### PR DESCRIPTION
## Summary
- fix typo in `updateCategories` function name
- update callers to use new name

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'vite-plugin-pwa/types', etc.)*